### PR TITLE
sk - added bg fixes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,14 +8,14 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@types/node": "^24.6.0",
-        "@types/react": "^19.1.16",
-        "@types/react-dom": "^19.1.9",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
         "@types/web-bluetooth": "^0.0.21",
         "@vitejs/plugin-react": "^5.0.4",
         "eslint": "^9.36.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@types/node": "^24.6.0",
-    "@types/react": "^19.1.16",
-    "@types/react-dom": "^19.1.9",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
     "@types/web-bluetooth": "^0.0.21",
     "@vitejs/plugin-react": "^5.0.4",
     "eslint": "^9.36.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,7 @@
+/// <reference types="vite/client" />
+/// <reference types="web-bluetooth" />
+
+import React from "react";
 import { useEffect, useRef, useState } from "react";
 
 const API = import.meta.env.VITE_API_BASE || "http://localhost:8787";

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,21 +1,12 @@
 {
   "compilerOptions": {
+    "jsx": "react-jsx",
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "allowImportingTsExtensions": true,
-    "jsx": "react-jsx",
-    "noEmit": true,
-
     "strict": true,
     "skipLibCheck": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-
     "types": ["vite/client", "web-bluetooth"]
   },
   "include": ["src"]


### PR DESCRIPTION
closes #12 
closes #13 

After the Pi setup we would be able to test #15 and close that aswell.

In this PR i have added frontend support for finding the Rpi devices based on:
const SERVICE_UUID    
const ID_CHAR_UUID    
const SIGN_NONCE_UUID  
const SIGN_RESP_UUID  

This would ensure it only looks for our Rpi's and not any random bluetooth device

For testing:

cd frontend 
npm run dev
localhost 5173

cd api
npm run dev
localhost 3000

run backend and frontend on separate terminals